### PR TITLE
Initialize Undebugger manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,7 @@ A menu can be triggered with default triggers:
 * On mobile device, single **tap with four fingers** with open or close menu
 
 Additionally, you can add your own triggers by calling `MenuTriggerService.RegisterTrigger`
+
+Fork change:
+call `UndebuggerRoot.Initialize();` to enable and `UndebuggerRoot.Destroy();` to destroy the root object
+https://github.com/kkostenkov/Undebugger/pull/1

--- a/Runtime/Scripts/UndebuggerRoot.cs
+++ b/Runtime/Scripts/UndebuggerRoot.cs
@@ -2,25 +2,36 @@
 #define UNDEBUGGER_ENABLED
 #endif
 
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Undebugger
 {
-    internal static class UndebuggerRoot
+    public static class UndebuggerRoot
     {
         public const string Version = "1.0.0";
 
 #if UNDEBUGGER_ENABLED
 
-        public static readonly GameObject Object;
-        public static readonly Transform Transform;
+        public static GameObject Object;
+        public static Transform Transform;
 
-        static UndebuggerRoot()
+        public static void Initialize()
         {
+            GameObject.Destroy(UndebuggerRoot.Object);
+            UndebuggerRoot.Transform = null;
+            
             Object = new GameObject("Undebugger");
             Object.hideFlags = HideFlags.NotEditable;
             Transform = Object.transform;
             GameObject.DontDestroyOnLoad(Object);
+        }
+
+        public static void Destroy()
+        {
+            GameObject.Destroy(UndebuggerRoot.Object);
+            UndebuggerRoot.Transform = null;
+
         }
 
         public static T CreateServiceInstance<T>(string name)


### PR DESCRIPTION
If Unity is setup not to clear static fields the plugin stops working from the second Playmode launch.

![image](https://github.com/user-attachments/assets/63a06bca-5f4c-429f-9233-275b5c8fdced)

Had to initialize it manually
